### PR TITLE
Stopped the `.gitconfig` user changes being overwritten fixes #13

### DIFF
--- a/ansible/provision.yml
+++ b/ansible/provision.yml
@@ -4,7 +4,7 @@
   gather_facts: false
   hosts: all
   vars:
-    ansible_python_interpreter: /usr/bin/python3
+    ansible_python_interpreter: /usr/bin/python3.6
   become: true
   tasks:
 
@@ -114,7 +114,7 @@
        - docker-ce=5:20.10.2~3-0~ubuntu-bionic
        - figlet=2.2.5-3
        - fonts-firacode=1.204-2
-       - gh=1.4.0
+       - gh=1.5.0
        - gnupg2=2.2.4-1ubuntu1.3
        - google-cloud-sdk-skaffold=323.0.0-0
        - google-cloud-sdk=323.0.0-0
@@ -260,10 +260,11 @@
         copy:
           src: '{{ item.src }}'
           dest: '{{ item.dest }}'
+          force: '{{ item.force }}'
         with_items:
-          - { name: gitconfig, src: ./config/gitconfig, dest: ~/.gitconfig }
-          - { name: gitignore, src: ./config/gitignore, dest: ~/.gitignore }
-          - { name: gitmessage, src: ./config/gitmessage, dest: ~/.gitmessage }
+          - { name: gitconfig, src: ./config/gitconfig, dest: ~/.gitconfig, force: no }
+          - { name: gitignore, src: ./config/gitignore, dest: ~/.gitignore, force: yes }
+          - { name: gitmessage, src: ./config/gitmessage, dest: ~/.gitmessage, force: yes }
         loop_control:
           label: '{{ item.name }}'
      become_user: vagrant

--- a/vagrantfile
+++ b/vagrantfile
@@ -17,7 +17,6 @@ Vagrant.configure("2") do |config|
   # mounts ansible scripts only
   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.synced_folder "./ansible", "/ansible"
-  config.vm.synced_folder "./ansible/scripts", "/home/vagrant/.scripts"
 
   # if packaging the box copies files otherwises syncs for better dev experience
   if packaging == 'true'
@@ -27,8 +26,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.provision "ansible_local" do |ansible|
-    ansible.version           = "2.9.16"
-    ansible.install_mode      = "pip"
+    ansible.version           = "2.9.17"
     ansible.provisioning_path = "/ansible"
     ansible.playbook          = "provision.yml"
     ansible.verbose           = false


### PR DESCRIPTION
**Purpose**

User changes based on actions or gh authentication processes thata re triggered automatically were being overwritten if the box was subsequently provisioned using `vagrant provision`.

**Approach**

Amended the git copy task in the provisioning to specific per file if the copy should be forced (a.k.a. overwritten)

**Refactoring**

* Bumped the Ansible Python version
* Bumper the Ansible version

**Issues**

[13](https://github.com/delineateio/box/issues/13)