### PR TITLE
Replaced the messy configuration and set up of `nginx` with `caddy`, Closes #15

### DIFF
--- a/ansible/config/Caddyfile
+++ b/ansible/config/Caddyfile
@@ -1,0 +1,8 @@
+clusters.getbox.io {
+        route * {
+                reverse_proxy 127.0.0.1:7777
+        }
+        tls {
+                dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+        }
+}

--- a/ansible/config/title
+++ b/ansible/config/title
@@ -1,1 +1,1 @@
-delineate.io
+box

--- a/ansible/provision.yml
+++ b/ansible/provision.yml
@@ -8,6 +8,8 @@
   become: true
   tasks:
 
+# bootstrap ------------------------------------------------------------
+
    - name: Create hush file
      file:
        path: ~/.hushlogin
@@ -49,13 +51,14 @@
         copy:
           src: ./config/timesyncd.conf
           dest: /etc/systemd/timesyncd.conf
-      - name: Set ntp On
+      - name: Set NTP on
         command: timedatectl set-ntp true
       - name: TimeSync service
         systemd:
           name: systemd-timesyncd.service
-          state: started
           enabled: yes
+          state: started
+          daemon_reload: yes
 
 # installs (apt) -----------------------------------------------------
 
@@ -124,6 +127,7 @@
        - libffi-dev=3.2.1-8
        - liblzma-dev=5.2.2-1.3
        - libncurses5-dev=6.1-1ubuntu1.18.04
+       - libnss3-tools=2:3.35-2ubuntu2.12
        - libreadline-dev=7.0-3
        - libsqlite3-dev=3.22.0-1ubuntu0.4
        - libssl-dev=1.1.1-1ubuntu2.1~18.04.7
@@ -133,7 +137,6 @@
        - make=4.1-9.1ubuntu1
        - mtr=0.92-1
        - neofetch=3.4.0-1
-       - nginx=1.14.0-0ubuntu1.7
        - nmap=7.60-1ubuntu5
        - nmon=16g+debian-3
        - osquery=4.5.1-1.linux
@@ -166,6 +169,7 @@
       - { name: octant, deb: 'https://github.com/vmware-tanzu/octant/releases/download/v0.16.3/octant_0.16.3_Linux-64bit.deb' }
       - { name: scala, deb: 'https://downloads.lightbend.com/scala/2.12.12/scala-2.12.12.deb' }
       - { name: trivy, deb: 'https://github.com/aquasecurity/trivy/releases/download/v0.9.1/trivy_0.9.1_Linux-64bit.deb' }
+      - { name: xcaddy, deb: 'https://github.com/caddyserver/xcaddy/releases/download/v0.1.7/xcaddy_0.1.7_linux_amd64.deb' }
      loop_control:
       label: '{{ item.name }}'
 
@@ -174,25 +178,19 @@
       autoremove: yes
       autoclean: yes
 
-# installs (other) ---------------------------------------------------
+# installs (tfenv) ---------------------------------------------------
+
    - name: Install tfenv
      block:
-     - name: Check if .local/bin directory exist
-       stat:
-         path: ~/.local/bin
-       register: local_bin
-
      - name: Create .local/bin directory
        file:
          path: ~/.local/bin
          state: directory
-       when: local_bin.stat.exists == false
-
      - name: Clone tfenv repository
        git:
          repo: https://github.com/tfutils/tfenv.git
          dest: ~/.tfenv
-
+         version: v2.0.0
      - name: Create symbolic links to tfenv scripts
        file:
          src: ~/.tfenv/bin/{{ item }}
@@ -201,8 +199,9 @@
        loop:
        - tfenv
        - terraform
-
      become_user: vagrant
+
+# installs (nvm & node)  ---------------------------------------------
 
    - name: Install nvm and node
      block:
@@ -211,7 +210,6 @@
          repo: https://github.com/nvm-sh/nvm.git
          dest: ~/.nvm
          version: v0.37.2
-
      - name: Install Node.js v10
        shell:
          cmd: 'source ~/.nvm/nvm.sh && {{ item }}'
@@ -220,11 +218,9 @@
        - nvm install --no-progress --default v10
        - nvm which default
        register: nvm
-
      - name: Get node/npm path from nvm
        shell: dirname '{{ nvm.results[-1].stdout }}'
        register: nvm_path
-
      become_user: vagrant
 
    - name: Install npm packages
@@ -243,6 +239,8 @@
      environment:
        PATH: '{{ nvm_path.stdout }}:{{ lookup("env", "PATH") }}'
 
+# installs (pip)  ----------------------------------------------------
+
    - name: Install pip packages
      pip:
       name:
@@ -250,12 +248,13 @@
        - detect-secrets==0.14.3
        - pre-commit==2.9.3
 
+# installs (unarchive)  ----------------------------------------------
+
    - block: # shell installs
       - name: Unarchive installs (root)
         unarchive:
           src: '{{ item.src }}'
           dest: '{{ item.dest }}'
-          creates: '{{ item.creates }}'
           remote_src: yes
         with_items:
           - { name: docker-credential-gcr, src: 'https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.0.2/docker-credential-gcr_linux_amd64-2.0.2.tar.gz', dest: /usr/local/bin/, creates: /usr/local/bin/docker-credential-gcr}
@@ -271,10 +270,83 @@
       mode: '755'
      with_items:
       - { name: hey, url: 'https://hey-release.s3.us-east-2.amazonaws.com/hey_linux_amd64', dest: /usr/local/bin/hey }
-      - { name: mkcert, url: 'https://github.com/FiloSottile/mkcert/releases/download/v1.4.3/mkcert-v1.4.3-linux-amd64', dest: /usr/local/bin/mkcert }
       - { name: st, url: 'https://storage.googleapis.com/container-structure-test/v1.9.1/container-structure-test-linux-amd64', dest: /usr/local/bin/container-structure-test }
      loop_control:
       label: '{{ item.name }}'
+
+# octant -------------------------------------------------------------
+
+   - block: # octant
+      - name: Add Octant service
+        copy:
+          remote_src: yes
+          src: ./services/octant.service
+          dest: /etc/systemd/system/octant.service
+          owner: root
+      - name: Start Octant service
+        systemd:
+          name: octant.service
+          enabled: yes
+          state: started
+          daemon_reload: yes
+
+# caddy --------------------------------------------------------------
+
+   - block: # caddy
+      - name: Create Caddy group
+        group:
+          name: caddy
+          state: present
+      - name: Add to Caddy group
+        user:
+          name: vagrant
+          groups: caddy
+          append: yes
+      - name: Build Caddy with Cloudflare plugin
+        shell: |
+          xcaddy build --output /tmp --with github.com/caddy-dns/cloudflare
+        args:
+          creates: /usr/bin/caddy
+        environment:
+          PATH: '/go/bin:{{ lookup("env", "PATH") }}'
+      - name: Moves Caddy to $PATH
+        command: mv /tmp/caddy /usr/bin/caddy
+        args:
+          creates: /usr/bin/caddy
+      - name: Enables Caddy port usage
+        command: setcap CAP_NET_BIND_SERVICE=+eip /usr/bin/caddy
+      - name: Create Caddy directory
+        file:
+          path: /etc/caddy
+          state: directory
+      - name: Add Caddyfile
+        copy:
+          src: ./config/Caddyfile
+          dest: /etc/caddy/Caddyfile
+      - name: Add Caddy service
+        copy:
+          remote_src: yes
+          src: ./services/caddy.service
+          dest: /etc/systemd/system/caddy.service
+          owner: root
+      - name: Start Octant service
+        systemd:
+          name: caddy.service
+          enabled: yes
+          state: started
+          daemon_reload: yes
+      - name: Add mappings to /etc/hosts
+        blockinfile:
+          path: /etc/hosts
+          block: |
+            {{ item.ip }} {{ item.name }}
+          marker: "#  host '{{ item.name }}' {mark} "
+        loop:
+          - { name: clusters.getbox.io, ip: 127.0.0.1 }
+        loop_control:
+          label: '{{ item.ip }} -> {{ item.name }}'
+     become: yes
+
 
    - block: # shell installs
       - name: Shell installs (root)
@@ -311,10 +383,12 @@
         git:
           repo: https://github.com/pyenv/pyenv.git
           dest: ~/.pyenv
+          version: v1.2.22
       - name: Clone pyenv-virtualenv
         git:
           repo: https://github.com/pyenv/pyenv-virtualenv.git
           dest: ~/.pyenv/plugins/pyenv-virtualenv
+          version: v1.1.5
       - name: Add pyenv variables
         blockinfile:
           path: ~/.bash_profile
@@ -342,6 +416,8 @@
           label: '{{ item }}'
       - name: Create virtual env
         command: ~/.pyenv/bin/pyenv virtualenv -f {{ item }} .venv{{ item }}
+        args:
+            creates: ~/.pyenv/versions/{{ item }}/envs/.venv{{ item }}/
         with_items:
           - 3.9.1
           - 3.8.5
@@ -356,7 +432,7 @@
         file:
           path: ~/.config
           state: directory
-      - name: Configure starship
+      - name: Configure Starship
         copy:
           src: ./config/starship.toml
           dest: ~/.config/starship.toml
@@ -368,7 +444,7 @@
 
 # git ----------------------------------------------------------------
 
-      - name: Configure git # git
+      - name: Configure Git # git
         copy:
           src: '{{ item.src }}'
           dest: '{{ item.dest }}'
@@ -388,18 +464,18 @@
         group:
           name: docker
           state: present
-      - name: Add Docker Group
+      - name: Add to Docker group
         user:
           name: vagrant
           groups: docker
           append: yes
-      - name: Start docker service
+      - name: Start Docker service
         systemd:
           name: docker.service
           daemon_reload: yes
           enabled: yes
           state: started
-      - name: Docker prune cron job
+      - name: Docker prune Cron job
         cron:
           name: docker prune
           hour: "02"
@@ -438,56 +514,6 @@
           mode: '600'
         become_user: vagrant
 
-# octant -------------------------------------------------------------
-
-   - block: # octant
-      - name: Add octant service
-        copy:
-          remote_src: yes
-          src: ./services/octant.service
-          dest: /etc/systemd/system/octant.service
-          owner: root
-      - name: Start octant service
-        systemd:
-          name: octant.service
-          enabled: yes
-          state: started
-          daemon_reload: yes
-
-# certs --------------------------------------------------------------
-
-   - block: # self signed cert
-      - name: Create tls directory
-        file:
-          path: /tls
-          state: directory
-          mode: '755'
-      - name: Generate tls certificate
-        shell: |
-          mkcert -uninstall
-          mkcert -install
-          mkcert -cert-file /tls/box.local.crt -key-file /tls/box.local.key 'box.local' localhost 127.0.0.1 ::1
-        args:
-          creates: /tls/box.local.crt
-
-# nginx --------------------------------------------------------------
-
-   - block: # nginx
-      - name: Remove default nginx config
-        file:
-          path: /etc/nginx/sites-enabled/default
-          state: absent
-      - name: Add nginx config
-        copy:
-          src: ./config/nginx.conf
-          dest: /etc/nginx/sites-enabled/nginx.conf
-      - name: Start nginx service
-        systemd:
-          name:  nginx.service
-          enabled: yes
-          state: started
-          daemon_reload: yes
-
 # project ------------------------------------------------------------
 
    - block: # project
@@ -496,6 +522,7 @@
           src:  https://github.com/delineateio/project/archive/latest.tar.gz
           dest: /tmp/
           remote_src: yes
+          creates: ~/project
       - name: Add Project
         command: mv /tmp/project-latest ~/project
         args:

--- a/ansible/services/caddy.service
+++ b/ansible/services/caddy.service
@@ -1,0 +1,35 @@
+# caddy.service
+#
+# For using Caddy with a config file.
+#
+# Make sure the ExecStart and ExecReload commands are correct
+# for your installation.
+#
+# See https://caddyserver.com/docs/install for instructions.
+#
+# WARNING: This service does not use the --resume flag, so if you
+# use the API to make changes, they will be overwritten by the
+# Caddyfile next time the service is restarted. If you intend to
+# use Caddy's API to configure it, add the --resume flag to the
+# `caddy run` command or use the caddy-api.service file instead.
+
+[Unit]
+Description=Caddy
+Documentation=https://caddyserver.com/docs/
+After=network.target network-online.target
+Requires=network-online.target
+
+[Service]
+User=vagrant
+Group=caddy
+ExecStart=/usr/bin/caddy run --environ --config /etc/caddy/Caddyfile
+ExecReload=/usr/bin/caddy reload --config /etc/caddy/Caddyfile
+TimeoutStopSec=5s
+LimitNOFILE=1048576
+LimitNPROC=512
+PrivateTmp=true
+ProtectSystem=full
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+[Install]
+WantedBy=multi-user.target

--- a/vagrantfile
+++ b/vagrantfile
@@ -32,12 +32,17 @@ Vagrant.configure("2") do |config|
     ansible.verbose           = false
   end
 
+  # these are not packaged but enables testing of of
+  config.vm.network "forwarded_port", guest: 80, host: 80, protocol: "tcp" # http
+  config.vm.network "forwarded_port", guest: 443, host: 443, protocol: "tcp" # https
+  config.vm.network "forwarded_port", guest: 5432, host: 5432, protocol: "tcp" # postgres
+
   # if packaging runs modified scripts from Chef bento project to minimise size
   if packaging == 'true'
     config.vm.provision "shell", path: "./package/cleanup.sh", :privileged => true
     config.vm.provision "shell", path: "./package/minimize.sh", :privileged => true
   end
 
-  config.vm.post_up_message = "You are now ready to develop for https://www.delineate.io"
+  config.vm.post_up_message = "You are now ready to develop for https://www.getbox.io"
 
 end


### PR DESCRIPTION
**Purpose**

The configuration and setup of `nginx` was quite messy and required the additional use of `mkcert`.  This still did not provide an end to end solution as the CA needs manually installing which was not slick.  Caddy has more native support for certificates, and specifically Cloudflare.  A new domain has been registered in Cloudflare to support this `getbox.io`.

**Approach**

* Removed the install and config of `nginx`
* Removed the insall and config `mkcert` which was used for `nginx` certs
* Added `systemd` configuration of `caddy.service`
* Added a block in `provisioning.yml` to install and config `caddy`
* Added `systemd` configuration of `caddy.service`
* Port forwarded `80` and `443` in `vagrantfile`
* Added a entry in `/etc/hosts` for `clusters.getbox.io`
* Updated documentation in line with the changes

**Refactoring**

* Change title file to change the title displayed in the `box`
* Renamed some of the Ansible tasks for consistency and removed some whitespace
* Removes an unnecessary stat for on the tfenv install
* Pinned all git clones to specific versions
* Configured additional tasks to use `creates` check so they are not repeated on `vagrant provision`

**Issues**

[Issue 15](https://github.com/delineateio/box/issues/15)
